### PR TITLE
gulp on prepublish

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
   "engines": {
     "node": ">=0.8.0"
   },
+  "scripts": {
+    "prepublish": "gulp"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/MichielvdVelde/novus-component.git"


### PR DESCRIPTION
Adds `gulp` to the `prepublish` script, removing the need to manually `gulp` before publishing.
