### PR TITLE
Add unsubscribe(), and 'once' to route options

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,8 @@ Options for this route.
 
 * `subscribe`: If set to `true`, the component will subscribe to this topic when
 it connects to the MQTT broker (default `true`).
+* `once`: If set to `true`, the topic will be unsubscribed to after the first message
+is received.
 
 ### .start()
 
@@ -254,8 +256,9 @@ any parameters you've used in the route (see above).
 
 ## Version history
 
-* v2.1.0 - v2.1.1 (17 Februari 2016)
-  * Moved `MemoryStore` to [its own package](https://github.com/MichielvdVelde/novus-component-store-memory)
+* v2.1.0 - v2.1.1 (17 February 2016)
+  * (2.2.0) Add `once` to route options
+  * (2.1.1) Moved `MemoryStore` to [its own package](https://github.com/MichielvdVelde/novus-component-store-memory)
 * v2.0.3 (13 Jan 2016)
   * Add support for basic plugins and custom component methods
 * v2.0.0 - 2.0.2 (10 Jan 2016)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "novus-component",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "Component framework for home automation",
   "author": {
     "name": "Michiel van der Velde",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "mqtt-regex": "^1.0.5",
     "novus-component-store-memory": "0.0.1"
   },
+  "scripts": {
+    "prepublish": "gulp"
+  },
   "engines": {
     "node": ">=0.8.0"
   },

--- a/src/Component.js
+++ b/src/Component.js
@@ -137,6 +137,21 @@ export class Component extends EventEmitter {
   }
 
   /**
+   * Unsubscribe from a topic
+  **/
+  unsubscribe(topic) {
+    return new Promise((resolve, reject) => {
+      if(!this.isConnected()) {
+        return reject(new Error('not connected'));
+      }
+      topic = this._replacePlaceholders(topic);
+      this._mqtt.unsubscribe(() => {
+        return resolve();
+      });
+    });
+  }
+
+  /**
    * Start the Component
   **/
   start() {

--- a/src/Component.js
+++ b/src/Component.js
@@ -253,6 +253,9 @@ export class Component extends EventEmitter {
   _matchTopicToRoute(topic) {
     for(let route of this._routes) {
       if(route.match(topic)) {
+        if(route.options.once) {
+          this.unsubscribe(route.topic);
+        }
         return route;
       }
     }


### PR DESCRIPTION
I noticed I didn't even write an 'unsubscribe' method, so I added that first.

Route options now includes an `once` option. Setting it to `true` will result in an `unsubscribe()` call on receipt of the first message on the topic.

Added a prepublish script to `package.json` that runs `gulp`.
